### PR TITLE
List status codes by type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /tmp/
 /config/env.yaml
 /*.gem
+test_dump.txt

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@
 /tmp/
 /config/env.yaml
 /*.gem
-test_dump.txt
+test.log

--- a/lib/hscode.rb
+++ b/lib/hscode.rb
@@ -19,7 +19,7 @@ module Hscode
 
       unless status_code
         puts "#{options.status_code} is not a valid code. See 'hscode --help'."
-        exit
+        exit 1
       end
 
       PrettyPrint.print(

--- a/lib/hscode.rb
+++ b/lib/hscode.rb
@@ -1,6 +1,7 @@
 require 'hscode/version'
 require 'hscode/input_parser'
 require 'hscode/http_status_codes'
+require 'hscode/status_code_types'
 require 'optparse'
 require 'ostruct'
 

--- a/lib/hscode/input_parser.rb
+++ b/lib/hscode/input_parser.rb
@@ -3,13 +3,6 @@ require 'hscode/pretty_print'
 module Hscode
   class InputParser
     attr_reader :options
-    CODE_REF = {
-      '1xx' => 'Informational',
-      '2xx' => 'Sucess',
-      '3xx' => 'Redirection',
-      '4xx' => 'Client Error',
-      '5xx' => 'Server Error'
-    }.freeze
 
     def initialize
       @options = OpenStruct.new
@@ -98,12 +91,11 @@ module Hscode
       raise OptionParser::InvalidOption unless type =~ /\A[1-5]x{2}\z/
 
       colour_code = type.to_s[0]
-      PrettyPrint.print("#{type} #{CODE_REF[type]}\n", colour_code)
+      PrettyPrint.print("#{type}   #{STATUS_CODE_TYPES[type]}\n", colour_code)
 
       http_group(type).map do |code, info_hash|
         PrettyPrint.print("#{code} - #{info_hash[:title]}", colour_code)
       end
-
       exit
     end
 

--- a/lib/hscode/input_parser.rb
+++ b/lib/hscode/input_parser.rb
@@ -67,9 +67,9 @@ module Hscode
 
     def list_status_codes_by_type(opts)
       opts.on('-l TYPE', '--list TYPE',
-              'List all HTTP status codes of that type') do
-
-        print_all_codes_by_type
+              'List all HTTP status codes of that type') do |type|
+        options.status_type = type
+        print_all_codes_by_type(type)
       end
     end
 
@@ -93,7 +93,7 @@ module Hscode
 
     def print_all_codes_by_type(type)
       HTTP_STATUS_CODES.map do |code, info_hash|
-        skip unless type.to_s.[0] == code.to_s[0]
+        next unless type.to_s[0] == code.to_s[0]
         colour_code = code.to_s[0]
         PrettyPrint.print("#{code} - #{info_hash[:title]}", colour_code)
       end

--- a/lib/hscode/input_parser.rb
+++ b/lib/hscode/input_parser.rb
@@ -36,7 +36,6 @@ module Hscode
         run_verbosely(opts)
         show_status_code(opts)
         list_status_codes(opts)
-        # list_status_codes_by_type(opts)
 
         opts.separator ''
 
@@ -60,11 +59,8 @@ module Hscode
     end
 
     def list_status_codes(opts)
-      # opts.on('-l', '--list', 'List all HTTP status codes') do
-      #   print_all_codes
-      # end
-
-      opts.on('-l', '--list [TYPE]', String, 'List all HTTP status type') do |type|
+      opts.on('-l', '--list [TYPE]',
+              'List all HTTP status codes of type') do |type|
         return print_all_codes unless type
         options.status_type = type
         print_all_codes_by_type(type)
@@ -85,6 +81,7 @@ module Hscode
           hscode -c 200
           hscode -c 200 -v
           hscode -l
+          hscode -l 2xx
         '
         exit
       end
@@ -98,18 +95,19 @@ module Hscode
     end
 
     def print_all_codes_by_type(type)
+      raise OptionParser::InvalidOption unless type =~ /\A[1-5]x{2}\z/
+
       colour_code = type.to_s[0]
-      PrettyPrint.print("#{type} #{CODE_REF[type]}", colour_code)
+      PrettyPrint.print("#{type} #{CODE_REF[type]}\n", colour_code)
 
       http_group(type).map do |code, info_hash|
         PrettyPrint.print("#{code} - #{info_hash[:title]}", colour_code)
       end
+
       exit
     end
 
     def http_group(type)
-      raise OptionParser::InvalidArgument unless type =~ /[1-5]x{2}/
-
       HTTP_STATUS_CODES.select do |code, _|
         type.start_with? code.to_s[0]
       end

--- a/lib/hscode/input_parser.rb
+++ b/lib/hscode/input_parser.rb
@@ -3,6 +3,13 @@ require 'hscode/pretty_print'
 module Hscode
   class InputParser
     attr_reader :options
+    CODE_REF = {
+      '1xx' => 'Informational',
+      '2xx' => 'Sucess',
+      '3xx' => 'Redirection',
+      '4xx' => 'Client Error',
+      '5xx' => 'Server Error'
+    }
 
     def initialize
       @options = OpenStruct.new
@@ -29,6 +36,7 @@ module Hscode
         run_verbosely(opts)
         show_status_code(opts)
         list_status_codes(opts)
+        list_status_codes_by_type(opts)
 
         opts.separator ''
 
@@ -57,6 +65,14 @@ module Hscode
       end
     end
 
+    def list_status_codes_by_type(opts)
+      opts.on('-l TYPE', '--list TYPE',
+              'List all HTTP status codes of that type') do
+
+        print_all_codes_by_type
+      end
+    end
+
     def display_help_message(opts)
       opts.on_tail('-h', '--help', 'Show this help message') do
         puts opts, 'Examples:
@@ -73,6 +89,15 @@ module Hscode
         puts Hscode::VERSION
         exit
       end
+    end
+
+    def print_all_codes_by_type(type)
+      HTTP_STATUS_CODES.map do |code, info_hash|
+        skip unless type.to_s.[0] == code.to_s[0]
+        colour_code = code.to_s[0]
+        PrettyPrint.print("#{code} - #{info_hash[:title]}", colour_code)
+      end
+      exit
     end
 
     def print_all_codes

--- a/lib/hscode/input_parser.rb
+++ b/lib/hscode/input_parser.rb
@@ -92,16 +92,19 @@ module Hscode
     end
 
     def print_all_codes_by_type(type)
-      HTTP_STATUS_CODES.map do |code, info_hash|
-        next if type.to_s[0] > code.to_s[0]
-        break if type.to_s[0] < code.to_s[0]
-        colour_code = code.to_s[0]
-        if (first = true)..false && first
-          PrettyPrint.print("#{type} #{CODE_REF[type]}", colour_code)
-        end
+      colour_code = type.to_s[0]
+      PrettyPrint.print("#{type} #{CODE_REF[type]}", colour_code)
+
+      http_group(type).map do |code, info_hash|
         PrettyPrint.print("#{code} - #{info_hash[:title]}", colour_code)
       end
       exit
+    end
+
+    def http_group(type)
+      HTTP_STATUS_CODES.select do |code, _|
+        type.start_with? code.to_s[0]
+      end
     end
 
     def print_all_codes

--- a/lib/hscode/input_parser.rb
+++ b/lib/hscode/input_parser.rb
@@ -92,11 +92,13 @@ module Hscode
     end
 
     def print_all_codes_by_type(type)
-      PrettyPrint.print("#{type} - #{CODE_REF[type]}", colour_code)
-
       HTTP_STATUS_CODES.map do |code, info_hash|
-        next unless type.to_s[0] == code.to_s[0]
+        next if type.to_s[0] > code.to_s[0]
+        break if type.to_s[0] < code.to_s[0]
         colour_code = code.to_s[0]
+        if (first = true)..false && first
+          PrettyPrint.print("#{type} #{CODE_REF[type]}", colour_code)
+        end
         PrettyPrint.print("#{code} - #{info_hash[:title]}", colour_code)
       end
       exit

--- a/lib/hscode/input_parser.rb
+++ b/lib/hscode/input_parser.rb
@@ -54,7 +54,7 @@ module Hscode
     def list_status_codes(opts)
       opts.on('-l', '--list [TYPE]',
               'List all HTTP status codes of type') do |type|
-        return print_all_codes unless type
+        print_all_codes unless type
         options.status_type = type
         print_all_codes_by_type(type)
       end

--- a/lib/hscode/input_parser.rb
+++ b/lib/hscode/input_parser.rb
@@ -36,7 +36,7 @@ module Hscode
         run_verbosely(opts)
         show_status_code(opts)
         list_status_codes(opts)
-        list_status_codes_by_type(opts)
+        # list_status_codes_by_type(opts)
 
         opts.separator ''
 
@@ -60,8 +60,14 @@ module Hscode
     end
 
     def list_status_codes(opts)
-      opts.on('-l', '--list', 'List all HTTP status codes') do
-        print_all_codes
+      # opts.on('-l', '--list', 'List all HTTP status codes') do
+      #   print_all_codes
+      # end
+
+      opts.on('-l', '--list [TYPE]', String, 'List all HTTP status type') do |type|
+        return print_all_codes unless type
+        options.status_type = type
+        print_all_codes_by_type(type)
       end
     end
 
@@ -102,6 +108,8 @@ module Hscode
     end
 
     def http_group(type)
+      raise OptionParser::InvalidArgument unless type =~ /[1-5]x{2}/
+
       HTTP_STATUS_CODES.select do |code, _|
         type.start_with? code.to_s[0]
       end

--- a/lib/hscode/input_parser.rb
+++ b/lib/hscode/input_parser.rb
@@ -9,7 +9,7 @@ module Hscode
       '3xx' => 'Redirection',
       '4xx' => 'Client Error',
       '5xx' => 'Server Error'
-    }
+    }.freeze
 
     def initialize
       @options = OpenStruct.new
@@ -92,6 +92,8 @@ module Hscode
     end
 
     def print_all_codes_by_type(type)
+      PrettyPrint.print("#{type} - #{CODE_REF[type]}", colour_code)
+
       HTTP_STATUS_CODES.map do |code, info_hash|
         next unless type.to_s[0] == code.to_s[0]
         colour_code = code.to_s[0]

--- a/lib/hscode/input_parser.rb
+++ b/lib/hscode/input_parser.rb
@@ -60,14 +60,6 @@ module Hscode
       end
     end
 
-    def list_status_codes_by_type(opts)
-      opts.on('-l TYPE', '--list TYPE',
-              'List all HTTP status codes of that type') do |type|
-        options.status_type = type
-        print_all_codes_by_type(type)
-      end
-    end
-
     def display_help_message(opts)
       opts.on_tail('-h', '--help', 'Show this help message') do
         puts opts, 'Examples:

--- a/lib/hscode/input_parser.rb
+++ b/lib/hscode/input_parser.rb
@@ -80,18 +80,25 @@ module Hscode
     end
 
     def print_all_codes_by_type(type)
-      raise OptionParser::InvalidOption unless type =~ /\A[1-5]x{2}\z/
+      unless type =~ /\A[1-5]x{2}\z/
+        abort "#{type} is not a valid code type. See 'hscode --help'."
+      end
 
       colour_code = type.to_s[0]
       PrettyPrint.print("#{type}   #{STATUS_CODE_TYPES[type]}\n", colour_code)
 
-      http_group(type).map do |code, info_hash|
-        PrettyPrint.print("#{code} - #{info_hash[:title]}", colour_code)
+      process_code_type(type, colour_code)
+    end
+
+    def process_code_type(type, colour)
+      code_type_group(type).map do |code, info_hash|
+        PrettyPrint.print("#{code} - #{info_hash[:title]}", colour)
       end
+
       exit
     end
 
-    def http_group(type)
+    def code_type_group(type)
       HTTP_STATUS_CODES.select do |code, _|
         type.start_with? code.to_s[0]
       end

--- a/lib/hscode/status_code_types.rb
+++ b/lib/hscode/status_code_types.rb
@@ -1,0 +1,9 @@
+module Hscode
+  STATUS_CODE_TYPES = {
+    '1xx' => 'Informational',
+    '2xx' => 'Sucess',
+    '3xx' => 'Redirection',
+    '4xx' => 'Client Error',
+    '5xx' => 'Server Error'
+  }.freeze
+end

--- a/lib/hscode/version.rb
+++ b/lib/hscode/version.rb
@@ -1,3 +1,3 @@
 module Hscode
-  VERSION = '0.1.1'.freeze
+  VERSION = '0.1.2'.freeze
 end

--- a/spec/exit_code_matchers.rb
+++ b/spec/exit_code_matchers.rb
@@ -1,0 +1,37 @@
+RSpec::Matchers.define :terminate do |_code|
+  actual = nil
+
+  def supports_block_expectations?
+    true
+  end
+
+  match do |block|
+    begin
+      block.call
+    rescue SystemExit => e
+      actual = e.status
+    end
+    actual && (actual == status_code)
+  end
+
+  chain :with_code do |status_code|
+    @status_code = status_code
+  end
+
+  failure_message do |_block|
+    "expected block to call exit(#{status_code}) but exit" +
+      (actual.nil? ? ' not called' : "(#{actual}) was called")
+  end
+
+  failure_message_when_negated do |_block|
+    "expected block not to call exit(#{status_code})"
+  end
+
+  description do
+    "expect block to call exit(#{status_code})"
+  end
+
+  def status_code
+    @status_code ||= 0
+  end
+end

--- a/spec/hscode/input_parser_spec.rb
+++ b/spec/hscode/input_parser_spec.rb
@@ -25,7 +25,7 @@ describe Hscode::InputParser do
           expect(options).to be_an_instance_of(OpenStruct)
           expect(options.verbose).to be nil
           expect(options.status_type).to eq('5xx')
-        end.to raise_error(SystemExit)
+        end.to terminate.with_code(0)
       end
     end
 
@@ -35,7 +35,7 @@ describe Hscode::InputParser do
           options = new_input_parser.parse(['-l'])
           expect(options).to be_an_instance_of(OpenStruct)
           expect(options.status_type).to be nil
-        end.to raise_error(SystemExit)
+        end.to terminate.with_code(0)
       end
     end
 
@@ -45,7 +45,7 @@ describe Hscode::InputParser do
           options = new_input_parser.parse(['--help'])
           expect(options).to be_an_instance_of(OpenStruct)
           expect { options }.to output.to_stdout
-        end.to raise_error(SystemExit)
+        end.to terminate.with_code(0)
       end
     end
 
@@ -55,7 +55,7 @@ describe Hscode::InputParser do
           options = new_input_parser.parse(['--version'])
           expect(options).to be_an_instance_of(OpenStruct)
           expect { options }.to output.to_stdout
-        end.to raise_error(SystemExit)
+        end.to terminate.with_code(0)
       end
     end
 
@@ -63,7 +63,7 @@ describe Hscode::InputParser do
       let(:options) { new_input_parser.parse(['-f']) }
 
       it 'raises an error' do
-        expect { options }.to raise_error SystemExit
+        expect { options }.to terminate.with_code(1)
       end
     end
   end

--- a/spec/hscode/input_parser_spec.rb
+++ b/spec/hscode/input_parser_spec.rb
@@ -18,7 +18,7 @@ describe Hscode::InputParser do
       end
     end
 
-    context 'valid list http code by type' do
+    context 'when option is `-l 5xx`' do
       it 'returns all http codes belonging to type' do
         expect do
           options = new_input_parser.parse(['-l', '5xx'])
@@ -26,6 +26,17 @@ describe Hscode::InputParser do
           expect(options.verbose).to be nil
           expect(options.status_type).to eq('5xx')
         end.to terminate.with_code(0)
+      end
+    end
+
+    context 'when option is `-l 5xc`' do
+      it 'should exit with status 1' do
+        expect do
+          options = new_input_parser.parse(['-l', '5xc'])
+          expect(options).to be_an_instance_of(OpenStruct)
+          expect(options.verbose).to be nil
+          expect(options.status_type).to eq('5xx')
+        end.to terminate.with_code(1)
       end
     end
 
@@ -44,7 +55,6 @@ describe Hscode::InputParser do
         expect do
           options = new_input_parser.parse(['--help'])
           expect(options).to be_an_instance_of(OpenStruct)
-          expect { options }.to output.to_stdout
         end.to terminate.with_code(0)
       end
     end
@@ -54,7 +64,6 @@ describe Hscode::InputParser do
         expect do
           options = new_input_parser.parse(['--version'])
           expect(options).to be_an_instance_of(OpenStruct)
-          expect { options }.to output.to_stdout
         end.to terminate.with_code(0)
       end
     end

--- a/spec/hscode/input_parser_spec.rb
+++ b/spec/hscode/input_parser_spec.rb
@@ -62,7 +62,7 @@ describe Hscode::InputParser do
     context 'Invalid requests' do
       let(:options) { new_input_parser.parse(['-f']) }
 
-      it 'raises an error' do
+      it 'exit with status 1' do
         expect { options }.to terminate.with_code(1)
       end
     end

--- a/spec/hscode/input_parser_spec.rb
+++ b/spec/hscode/input_parser_spec.rb
@@ -39,6 +39,26 @@ describe Hscode::InputParser do
       end
     end
 
+    context 'when option is --help' do
+      it 'displays help message' do
+        expect do
+          options = new_input_parser.parse(['--help'])
+          expect(options).to be_an_instance_of(OpenStruct)
+          expect { options }.to output.to_stdout
+        end.to raise_error(SystemExit)
+      end
+    end
+
+    context 'when option is --version' do
+      it 'displays version' do
+        expect do
+          options = new_input_parser.parse(['--version'])
+          expect(options).to be_an_instance_of(OpenStruct)
+          expect { options }.to output.to_stdout
+        end.to raise_error(SystemExit)
+      end
+    end
+
     context 'Invalid requests' do
       let(:options) { new_input_parser.parse(['-f']) }
 

--- a/spec/hscode/input_parser_spec.rb
+++ b/spec/hscode/input_parser_spec.rb
@@ -18,11 +18,32 @@ describe Hscode::InputParser do
       end
     end
 
+    context 'valid list http code by type' do
+      it 'returns all http codes belonging to type' do
+        expect do
+          options = new_input_parser.parse(['-l', '5xx'])
+          expect(options).to be_an_instance_of(OpenStruct)
+          expect(options.verbose).to be nil
+          expect(options.status_type).to eq('5xx')
+        end.to raise_error(SystemExit)
+      end
+    end
+
+    context 'list all http codes' do
+      it 'returns all http codes' do
+        expect do
+          options = new_input_parser.parse(['-l'])
+          expect(options).to be_an_instance_of(OpenStruct)
+          expect(options.status_type).to be nil
+        end.to raise_error(SystemExit)
+      end
+    end
+
     context 'Invalid requests' do
       let(:options) { new_input_parser.parse(['-f']) }
 
       it 'raises an error' do
-        expect { options }.to raise_error
+        expect { options }.to raise_error SystemExit
       end
     end
   end

--- a/spec/hscode_spec.rb
+++ b/spec/hscode_spec.rb
@@ -34,7 +34,9 @@ describe Hscode do
         let(:error_msg) { "800 is not a valid code. See 'hscode --help'." }
 
         it 'prints an error message' do
-          expect(invalid_code).to be_eql error_msg
+          expect do
+            expect(invalid_code).to be_eql error_msg
+          end.to terminate.with_code(1)
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,7 +23,8 @@ require 'rspec'
 RSpec.configure do |config|
   config.before(:all) do
     @original_stdout = $stdout
-    $stdout = File.new(File.join(File.dirname(__FILE__), 'test_dump.txt'), 'w')
+    $stdout = File.new(File.join(File.dirname(__FILE__), 'test.log'), 'w')
+    Pry.output = @original_stdout
   end
 
   config.after(:all) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'simplecov'
 require 'coveralls'
 require 'pry'
+require 'exit_code_matchers'
 
 Coveralls.wear!
 
@@ -23,4 +24,4 @@ RSpec.configure do |config|
   # custom RSpec configurations
 end
 
-ENV["RUBY_ENV"] = "test"
+ENV['RUBY_ENV'] = 'test'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,15 @@ require 'hscode'
 require 'rspec'
 
 RSpec.configure do |config|
-  # custom RSpec configurations
+  config.before(:all) do
+    @original_stdout = $stdout
+    $stdout = File.new(File.join(File.dirname(__FILE__), 'test_dump.txt'), 'w')
+  end
+
+  config.after(:all) do
+    $stdout = @original_stdout
+    @original_stdout = nil
+  end
 end
 
 ENV['RUBY_ENV'] = 'test'


### PR DESCRIPTION
#### What does this PR do?

- Enables status code to be listed by type
- Ensures successful commands exits with 0 while unsuccessful exits with 1
- Introduces RSpec matchers for handling exit codes
- Suppresses outputting to console and logs to a file `spec/test.log`
- Increases test coverage

Closes #16